### PR TITLE
Update straight.el instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ## via straight.el
 
   ```emacs-lisp
-  (straight-use-package '(asm-blox :host github :repo "zkry/asm-blox"))
+  (straight-use-package 'asm-blox)
   ```
 # Selecting a Puzzle
 


### PR DESCRIPTION
Because `straight.el` can pull from MELPA directly, the github instructions aren't needed :)