### PR TITLE
prevent saving on corrupted (unparsable) files

### DIFF
--- a/asm-blox.el
+++ b/asm-blox.el
@@ -3300,6 +3300,13 @@ The follwoing commadns are defined:
 (defvar asm-blox--show-pair-idle-timer nil
   "Idle-timer for showing matching parenthesis.")
 
+(defun asm-blox--ensure-buffer-not-empty ()
+  (let ((parse (ignore-errors (asm-blox--parse-saved-buffer))))
+    (if parse
+        nil
+      (message "File corrupted; unable to save.xo")
+      t)))
+
 (define-derived-mode asm-blox-mode fundamental-mode "asm-blox"
   "Major mode for editing `asm-blox' puzzles.
 
@@ -3328,6 +3335,7 @@ The following commands are available:
   (unless asm-blox--show-pair-idle-timer
     (setq asm-blox--show-pair-idle-timer
           (run-with-idle-timer 0.125 t #'asm-blox--highlight-pairs)))
+  (add-hook 'write-file-functions #'asm-blox--ensure-buffer-not-empty nil t)
   (asm-blox-eldoc-setup))
 
 ;;;###autoload


### PR DESCRIPTION
This PR adds a function to the "write-file-functions" hook so that in order for the file to be saved, it must first properly parse. This is to prevent some error that corrupts the savefile from overwriting good data.