### PR TITLE
make level selection buttons clickable

### DIFF
--- a/asm-blox.el
+++ b/asm-blox.el
@@ -3671,10 +3671,13 @@ The following commands are available:
           (let ((saved-file-ids (asm-blox--saved-puzzle-ct-ids name)))
             (dolist (i saved-file-ids)
               (insert
-               (propertize (format "[%d]" i)
-                           'asm-blox-puzzle-selection-id name
-                           'asm-blox-puzzle-selection-filename
-                           (asm-blox--make-puzzle-idx-file-name name i)))
+               (button-buttonize
+                (propertize (format "[%d]" i)
+                            'asm-blox-puzzle-selection-id name
+                            'asm-blox-puzzle-selection-filename
+                            (asm-blox--make-puzzle-idx-file-name name i))
+                (lambda (_)
+                  (asm-blox-select-puzzle))))
               (insert (propertize " " 'asm-blox-puzzle-selection-id name)))))
         (insert "\n")))))
 


### PR DESCRIPTION
This little change makes the items in the level selection clickable.