### PR TITLE
Fix sequence peak detector output locations

### DIFF
--- a/asm-blox-puzzles.el
+++ b/asm-blox-puzzles.el
@@ -939,7 +939,7 @@ Find the pattern 0, 0, 0:
                                                   :name "I"))
      :sinks
      (list (asm-blox--cell-sink-create :row 3
-                                       :col 2
+                                       :col 1
                                        :expected-data output-n
                                        :name "N")
            (asm-blox--cell-sink-create :row 3


### PR DESCRIPTION
Fixes #25 

There was a typo in the puzzle definition for `asm-blox-puzzles--sequence-peak-detector`. This PR fixes this.
